### PR TITLE
fix: prevent SVG icons from becoming excessively large

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,12 @@
   .dark body {
     @apply bg-dark-950 text-dark-100;
   }
+
+  /* Prevent SVGs from becoming excessively large if utility classes are lost */
+  svg {
+    max-width: 100%;
+    height: auto;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
Added protective CSS rules to prevent SVG icons from becoming excessively large if Tailwind utility classes are not applied or get purged during deployment.

## Changes
- Added `svg { max-width: 100%; height: auto; }` to src/index.css
- This ensures SVGs maintain proper sizing even if w-/h- utility classes are lost

## Testing
- Verified the rule appears in built CSS
- Ran lint and build successfully
- Confirmed no regressions in icon sizing when classes are properly applied

Fixes the issue where deployed SVG icons were appearing huge due to missing utility classes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shazzar00ni/docugen/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
