### PR TITLE
Add CLAUDE.md with codebase guidance for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Dev server at http://localhost:3000
+npm run build        # Production build → dist/
+npm run preview      # Serve the production build locally
+npm run lint         # ESLint, fails on any warning (--max-warnings 0)
+npm run lint:fix     # ESLint with auto-fix
+npm run format       # Prettier write
+npm run typecheck    # tsc --noEmit (TypeScript check without emitting)
+npm run test         # Vitest in watch mode
+npm run test:run     # Vitest single run (use before committing)
+npm run e2e          # Playwright end-to-end tests (requires a running dev server)
+```
+
+To run a single unit test file: `npx vitest run src/components/Navbar.test.tsx`
+
+Pre-commit hook runs `lint-staged`: ESLint --fix + Prettier --write on staged `.ts`/`.tsx`/`.js`/`.jsx` files.
+
+## Architecture
+
+DocuGen is a **single-page marketing/landing site** (no client-side router). Navigation is anchor-based (`#features`, `#pricing`, etc.). The app has no backend; all content is static.
+
+### Application entry
+
+`main.tsx` → wraps `<App>` in `<ThemeProvider>` → `App.tsx` renders the full page as a vertical stack of sections.
+
+Above-fold sections (`Hero`, `HowItWorks`, `FAQ`) are eagerly imported. Below-fold sections (`Features`, `Testimonials`, `Preview`, `Pricing`, `Newsletter`) use `React.lazy` + `<Suspense>` for code splitting.
+
+### Content layer
+
+**All copy lives in `src/data/content.ts`.** Never hardcode strings inside components. The file exports named constants (`HERO_COPY`, `FEATURES`, `FAQS`, `PRICING_COPY`, etc.) consumed directly in components.
+
+### Theme system
+
+`src/lib/ThemeContext.tsx` provides a React Context with `theme`, `toggleTheme`, and `setTheme`. Initial theme is read from `localStorage` (`docugen-theme`) and falls back to `prefers-color-scheme`. Theme is applied by toggling the `dark` class on `<html>`. Tailwind is configured with `darkMode: 'class'`.
+
+Consume theme in components via the `useTheme` hook from `src/lib/useTheme.ts`.
+
+### Design tokens
+
+Custom Tailwind palette defined in `tailwind.config.js`:
+- `teal-*` — primary accent color (e.g. `text-teal-400`, `bg-teal-600`)
+- `dark-*` / `light-*` — semantic scale for text/backgrounds
+- Fonts: `font-sans` → Inter, `font-mono` → JetBrains Mono
+
+Avoid arbitrary Tailwind values (`[...]`); extend the theme instead.
+
+### Animations
+
+Use Framer Motion only for entrance animations (`motion.div` with `initial`/`animate`/`whileInView`). Always set `viewport={{ once: true }}`. Duration: `0.5s` standard, `0.6s` complex. Stagger children with `delay: index * 0.1`. No spring or bounce effects.
+
+## Code Conventions
+
+- **Named exports only** — no default exports for components.
+- **Absolute imports** from `src/` (TypeScript `moduleResolution: "bundler"` is configured; use `./` or `../` only when needed by tooling).
+- **Import order**: React → external packages → internal components/utils.
+- **No `any` types** — ESLint enforces `@typescript-eslint/no-explicit-any: error`. Use `unknown` with type guards.
+- **Unused variables/params** cause build errors (`noUnusedLocals`, `noUnusedParameters` in `tsconfig.json`). Prefix with `_` to suppress if intentional.
+- **Component file order**: imports → types/interfaces → constants → helper functions → main component → exports.
+- **Component naming**: PascalCase for files and components; camelCase for utilities.
+
+## Testing
+
+Unit tests use Vitest + React Testing Library. Test files live **next to** the component they test with a `.test.tsx` extension (e.g. `FAQ.tsx` → `FAQ.test.tsx`).
+
+`src/test/setup.ts` provides global mocks for every test:
+- `localStorage` — vi.fn() mock (reset `beforeEach`)
+- `IntersectionObserver` — stubbed no-op class
+
+E2E tests are in `e2e/` using Playwright. They require the dev server to already be running (`npm run dev` in a separate terminal).
+
+## Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `VITE_PLAUSIBLE_DOMAIN` | Enables Plausible analytics (optional; no analytics if unset) |
+
+Prefix all client-side env vars with `VITE_` (Vite requirement).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ DocuGen is a **single-page marketing/landing site** (no client-side router). Nav
 
 ### Application entry
 
-`main.tsx` → wraps `<App>` in `<ThemeProvider>` → `App.tsx` renders the full page as a vertical stack of sections.
+`main.tsx` mounts `<App>` inside `<React.StrictMode>`. `App.tsx` owns the `<ThemeProvider>` wrapper and renders the full page as a vertical stack of sections.
 
 Above-fold sections (`Hero`, `HowItWorks`, `FAQ`) are eagerly imported. Below-fold sections (`Features`, `Testimonials`, `Preview`, `Pricing`, `Newsletter`) use `React.lazy` + `<Suspense>` for code splitting.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ npm run test:run     # Vitest single run (use before committing)
 npm run e2e          # Playwright end-to-end tests (requires a running dev server)
 ```
 
-To run a single unit test file: `npx vitest run src/components/Navbar.test.tsx`
+To run a single unit test file: `npx vitest run src/components/FAQ.test.tsx`
 
 Pre-commit hook runs `lint-staged`: ESLint --fix + Prettier --write on staged `.ts`/`.tsx`/`.js`/`.jsx` files.
 
@@ -33,7 +33,7 @@ Above-fold sections (`Hero`, `HowItWorks`, `FAQ`) are eagerly imported. Below-fo
 
 ### Content layer
 
-**All copy lives in `src/data/content.ts`.** Never hardcode strings inside components. The file exports named constants (`HERO_COPY`, `FEATURES`, `FAQS`, `PRICING_COPY`, etc.) consumed directly in components.
+Copy should live in `src/data/content.ts`, which exports named constants (`HERO_COPY`, `FEATURES`, `FAQS`, `PRICING_COPY`, etc.) consumed directly in components. Some components (e.g. `Navbar`) still contain inline strings not yet migrated to `content.ts`; new copy should go in `content.ts`.
 
 ### Theme system
 
@@ -57,7 +57,7 @@ Use Framer Motion only for entrance animations (`motion.div` with `initial`/`ani
 ## Code Conventions
 
 - **Named exports only** — no default exports for components.
-- **Absolute imports** from `src/` (TypeScript `moduleResolution: "bundler"` is configured; use `./` or `../` only when needed by tooling).
+- **Relative imports** — `tsconfig.json` uses `moduleResolution: "bundler"` but has no `baseUrl`/`paths` and `vite.config.ts` has no aliases, so use `./` or `../` paths throughout.
 - **Import order**: React → external packages → internal components/utils.
 - **No `any` types** — ESLint enforces `@typescript-eslint/no-explicit-any: error`. Use `unknown` with type guards.
 - **Unused variables/params** cause build errors (`noUnusedLocals`, `noUnusedParameters` in `tsconfig.json`). Prefix with `_` to suppress if intentional.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to provide structured guidance for future Claude Code sessions working in this repository
- Documents all development commands (dev, build, lint, typecheck, test, e2e) including how to run a single test file
- Explains the high-level architecture: single-page landing site with anchor navigation, lazy-loaded below-fold sections, centralized content in `src/data/content.ts`, theme system via React Context + localStorage + Tailwind `dark` class
- Captures code conventions (named exports only, no `any`, import order, component file structure) and testing setup (global mocks for `localStorage` and `IntersectionObserver`)

## Test plan

- [x] Verify commands listed in CLAUDE.md match `package.json` scripts
- [x] Confirm architecture description matches current `src/App.tsx` and `src/lib/ThemeContext.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ProhZcrkuekv742hSoWLct)_